### PR TITLE
Fix handling agadoo return code in GH workflow

### DIFF
--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -40,7 +40,7 @@ jobs:
           STDOUT_F=$(mktemp)
           STDERR_F=$(mktemp)
           # Run agadoo and capture errors without breaking the workflow
-          (agadoo 2> $STDERR_F > $STDOUT_F || RET=$? && RET=$? ) ||:
+          $(agadoo 2> $STDERR_F > $STDOUT_F) && true; RET=?
 
           # In order to be used in GH actions `echo "::set-output` the
           # multi-line output must be escaped.

--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -90,4 +90,4 @@ jobs:
 
             </details>
           check_for_duplicate_msg: false
-          delete_prev_regex_msg: "**Check tree-shakeability** :deciduous_tree: "
+          delete_prev_regex_msg: ^\*\*Check tree-shakeability\*\* :deciduous_tree


### PR DESCRIPTION

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [ ] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

The return code of `agadoo` was not correctly captured and resulted
in a non-zero value even in successful executions.
See https://github.com/italia/design-react-kit/runs/4672835228 output in the `Run agadoo` step


#### Changes proposed in this Pull Request:

- Simplify and correct `agadoo` exit code
- Fix regex used to delete any previous comment made by this workflow on the PR


I'm sorry for the inconvenience this time I've checked the bash login using:

```bash
# GH workflow steps are run with set -e
bash -e
bash-3.2$ $(false) && true; ret=$?
bash-3.2$ echo $?
0
bash-3.2$ echo $ret
1
bash-3.2$ $(true) && true; ret=$?
bash-3.2$ echo $?
0
bash-3.2$ echo $ret
0 
```

